### PR TITLE
Remove deprecated usage of TimeVortex Pointers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,8 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wmissing-format-attribute -Wsuggest-final-methods -Wsuggest-final-types -Wvolatile")
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wvla -Wuninitialized -Wdouble-promotion -Wsign-conversion -Wconversion -Wno-unused-parameter -Wno-deprecated-declarations -Wno-macro-redefined ${WERROR_FLAG} ${SANITIZE_FLAG} ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS}")
+#set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wvla -Wuninitialized -Wdouble-promotion -Wsign-conversion -Wconversion -Wno-unused-parameter -Wno-deprecated-declarations -Wno-macro-redefined ${WERROR_FLAG} ${SANITIZE_FLAG} ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++17 ${FP_MODE_FLAG} -O2 -Wall -Wextra -Wsuggest-override -Wvla -Wuninitialized -Wdouble-promotion -Wsign-conversion -Wconversion -Wno-unused-parameter -Wno-macro-redefined ${WERROR_FLAG} ${SANITIZE_FLAG} ${CMAKE_CXX_FLAGS} -I./ ${LDFLAGS}")
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -Wall")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -Wall")

--- a/sstcomp/include/SST.h
+++ b/sstcomp/include/SST.h
@@ -16,7 +16,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+// #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma GCC diagnostic ignored "-Wsuggest-override"
 #pragma GCC diagnostic ignored "-Wdouble-promotion"
 #pragma GCC diagnostic ignored "-Wsign-conversion"

--- a/sstcomp/neuralnet/nn_batch_controller.cc
+++ b/sstcomp/neuralnet/nn_batch_controller.cc
@@ -41,7 +41,8 @@ NNBatchController::NNBatchController(SST::ComponentId_t id, const SST::Params& p
   const std::string systemClock = params.find< std::string >("clockFreq", "1GHz");
   clockHandler  = new SST::Clock::Handler2<NNBatchController,&NNBatchController::clockTick>(this);
   timeConverter = registerClock(systemClock, clockHandler);
-
+  output.verbose(CALL_INFO, 10, 0, "register clock: &timeConverter=%p factor=%" PRIx64 "\n", &timeConverter, timeConverter.getFactor());
+  
   // Configure Links
   linkHandlers[PortTypes::forward_i] = 
     configureLink(PortNames.at(PortTypes::forward_i),
@@ -73,11 +74,13 @@ void NNBatchController::init( unsigned int phase ){
   // Currently only one controller. Indicated init phase to
   // show that interactive debug does not address it.
   output.verbose( CALL_INFO, 0,0, "init phase %" PRId32 "\n", phase);
+  output.verbose(CALL_INFO, 10, 0, "init check register clock: &timeConverter=%p factor=%" PRIx64 "\n", &timeConverter, timeConverter.getFactor());
 }
 
 void NNBatchController::setup(){
   // Similar to init, let the user know  
   output.verbose( CALL_INFO, 0,0, "setup\n");
+   output.verbose(CALL_INFO, 10, 0, "init check register clock: &timeConverter=%p factor=%" PRIx64 "\n", &timeConverter, timeConverter.getFactor());
 
   if (!enableTraining() && !enableValidation() && !enableEvaluation())
     output.fatal(CALL_INFO, -1, "Nothing to do. Please set --trainingImages, --testImages, and/or --evalImages");
@@ -165,6 +168,7 @@ void NNBatchController::backward_i_rcv(SST::Event *ev) {
   
   // Signal to send the next batch
   readyToSend = true;
+  output.verbose(CALL_INFO, 10, 0, "reregister clock: &timeConverter=%p factor=%" PRIx64 "\n", &timeConverter, timeConverter.getFactor());
   reregisterClock(timeConverter, clockHandler);
   delete(ev);
 }
@@ -186,10 +190,12 @@ void NNBatchController::monitor_rcv(SST::Event *ev) {
     accumulatedSums.current_learning_rate = monitor_payload.optimizer_data.current_learning_rate;
   
     readyToSend = true;
+    output.verbose(CALL_INFO, 10, 0, "reregister clock: &timeConverter=%p factor=%" PRIx64 "\n", &timeConverter, timeConverter.getFactor());
     reregisterClock(timeConverter, clockHandler);
   } else if (mode == MODE::EVALUATION) {
     // std::cout << "predictions=" << monitor_payload.predictions.transpose() << std::endl;
     readyToSend = true;
+    output.verbose(CALL_INFO, 10, 0, "reregister clock: &timeConverter=%p factor=%" PRIx64 "\n", &timeConverter, timeConverter.getFactor());
     reregisterClock(timeConverter, clockHandler);
   } else {
     assert(mode == MODE::TRAINING);

--- a/sstcomp/neuralnet/nn_batch_controller.h
+++ b/sstcomp/neuralnet/nn_batch_controller.h
@@ -83,7 +83,7 @@ public:
 private:
   // -- SST handlers
   SST::Output    output;                          ///< SST output handler
-  TimeConverter* timeConverter;                   ///< SST time conversion handler
+  TimeConverter  timeConverter;                   ///< SST time conversion handler
   SST::Clock::HandlerBase* clockHandler;          ///< Clock Handler
 
   // -- Component Parameters  

--- a/sstcomp/neuralnet/nn_layer.cc
+++ b/sstcomp/neuralnet/nn_layer.cc
@@ -44,7 +44,9 @@ NNLayer::NNLayer(SST::ComponentId_t id, const SST::Params& params ) :
   const std::string systemClock = params.find< std::string >("clockFreq", "1GHz");
   clockHandler_  = new SST::Clock::Handler2<NNLayer,&NNLayer::clockTick>(this);
   timeConverter_ = registerClock(systemClock, clockHandler_);
+  sstout_.verbose(CALL_INFO, 10, 0, "register clock: &timeConverter_=%p factor=%" PRIx64 "\n", &timeConverter_, timeConverter_.getFactor());
   // an event will wake up the clocking
+  sstout_.verbose(CALL_INFO, 10, 0, "unregister clock: &timeConverter_=%p factor=%" PRIx64 "\n", &timeConverter_, timeConverter_.getFactor());
   unregisterClock(timeConverter_, clockHandler_);
 
   // subcomponents
@@ -81,10 +83,11 @@ NNLayer::~NNLayer(){
 }
 
 void NNLayer::init( unsigned int phase ){
-
+  sstout_.verbose(CALL_INFO, 10, 0, "init check register clock: &timeConverter_=%p factor=%" PRIx64 "\n", &timeConverter_, timeConverter_.getFactor());
 }
 
 void NNLayer::setup(){
+  sstout_.verbose(CALL_INFO, 10, 0, "setup check register clock: &timeConverter_=%p factor=%" PRIx64 "\n", &timeConverter_, timeConverter_.getFactor());
 }
 
 void NNLayer::complete( unsigned int phase ){
@@ -192,7 +195,8 @@ void NNLayer::forward_i_rcv(SST::Event *ev){
   }
   else
     driveForwardPass_ = true;
-
+ 
+  sstout_.verbose(CALL_INFO, 10, 0, "reregister clock: &timeConverter_=%p factor=%" PRIx64 "\n", &timeConverter_, timeConverter_.getFactor());
   reregisterClock(timeConverter_, clockHandler_);
   delete ev;
 }
@@ -201,7 +205,7 @@ void NNLayer::backward_i_rcv(SST::Event *ev){
   NNEvent *nnev = static_cast<NNEvent*>(ev);
   backwardData_i = nnev->payload();
   driveBackwardPass_ = true;
-
+  sstout_.verbose(CALL_INFO, 10, 0, "reregister clock: &timeConverter_=%p factor=%" PRIx64 "\n", &timeConverter_, timeConverter_.getFactor());
   reregisterClock(timeConverter_, clockHandler_);
   delete ev;
 }

--- a/sstcomp/neuralnet/nn_layer.h
+++ b/sstcomp/neuralnet/nn_layer.h
@@ -77,7 +77,7 @@ private:
 
   // -- SST handlers
   SST::Output    sstout_; 
-  TimeConverter* timeConverter_;
+  TimeConverter timeConverter_;
   SST::Clock::HandlerBase* clockHandler_;
 
   // internals

--- a/sstcomp/omap/omap.h
+++ b/sstcomp/omap/omap.h
@@ -163,7 +163,7 @@ private:
 
   // SST Handlers
   SST::Output sstout_;
-  SST::TimeConverter* timeConverter_;
+  SST::TimeConverter timeConverter_;
   SST::Clock::HandlerBase* clockHandler_;
 
   // Links

--- a/test/neuralnet/nn-basic.sh
+++ b/test/neuralnet/nn-basic.sh
@@ -21,7 +21,7 @@ fi
 
 if [ $largesim -eq 0 ]; then
     echo "Running small simulation"
-    sst ../test-image.py ${SSTOPTS} -- \
+    sst ../test-image.py ${SSTOPTS} --verbose=${VERBOSE} -- \
         --batchSize=1 \
         --classImageLimit=4 \
         --epochs=4 \
@@ -33,7 +33,7 @@ if [ $largesim -eq 0 ]; then
         --verbose=${verbose}
 else
     echo "Running large simulation"
-    sst ../test-image.py ${SSTOPTS} -- \
+    sst ../test-image.py ${SSTOPTS} --verbose=${VERBOSE} -- \
         --batchSize=128 \
         --epochs=10 \
         --evalImages="${IMAGE_DATA}/eval" \


### PR DESCRIPTION
Using pointers to TimeVortex's is deprecated. This PR fixes all deprecation warnings and makes sure they are no longer ignored in the compile.  The version with the pointers is preserved in branch `test-for-sst-core-1537`. Note that compiling for sst-15.1.0 will need to be done with -DSST_TOOLS_WERROR=OFF.

@skuntz I've not yet tested that the demo still works. If you can check that your latest updates work that should be sufficient to approve for merge.
